### PR TITLE
Fix spacing gap between FilterBar and Cards

### DIFF
--- a/src/app/src/lib/components/Card.svelte
+++ b/src/app/src/lib/components/Card.svelte
@@ -123,18 +123,18 @@
     overflow-x: hidden;
   }
 
-  /**
+/**
    * Main card container.
-   * Displays game image on the left and content on the right.
    */
   .card {
     background-color: variables.$secondary;
     height: 30%;
     width: 90%;
-    display: flex; /* Arrange image and content side by side */
+    display: flex;
     justify-content: left;
     border: none;
-    margin: 20px 30px; /* Space between cards */
+    
+    margin: 0 30px 20px 30px; 
   }
 
   /**

--- a/src/app/src/lib/components/Cards.svelte
+++ b/src/app/src/lib/components/Cards.svelte
@@ -107,13 +107,16 @@
 
 <style lang="scss">
   @use '$lib/styles/variables';
-
-  .cards {
+.cards {
+  
+    margin-top: 15px;
+    padding-top: 0 !important;
+    
     margin-left: auto; 
     width: 85%;
     display: flex;
     flex-direction: column;
-    list-style: none; 
+    list-style: none;
   }
 
   :global(.cards li) {

--- a/src/app/src/routes/+layout.svelte
+++ b/src/app/src/routes/+layout.svelte
@@ -29,14 +29,15 @@
 
 <style>
   main {
-    margin-top: 130px; /* Accounts for both Nav and FilterBar height */
-    padding: 20px;
-    
-    /* Center the content horizontally */
+
+    margin-top: 15px; 
+
+    padding: 0 20px 20px 20px; 
+
     display: flex;
     flex-direction: column;
     align-items: center; 
     width: 100%;
-    box-sizing: border-box;
+    box-sizing: border-box; 
   }
 </style>


### PR DESCRIPTION
+layout.svelte:

        Adjusted margin-top to 25px to provide the correct offset for the navigation headers.

        Set padding-top to 0 to remove the internal container cushion.

    Cards.svelte:

        Updated the .cards class to set margin-top: 0 and padding-top: 0.

        This ensures the list container itself doesn't introduce a gap at the top of the main section.

    Card.svelte:

        Updated the .card class margin to 0 30px 20px 30px.

        This removes the top margin from individual cards while maintaining the bottom spacing between items in the list.

Linked Issues
Closes #81 